### PR TITLE
Expose macros within root crate hidden behind macros feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target
+/target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,15 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+macros = []
+
+[workspace]
+members = [
+    "binmarshal-macros",
+    ".",
+]
+
 [dependencies]
 binmarshal-macros = { version = "^0.1.0", path = "binmarshal-macros", default-features = false }
 schemars = { version = "0.8.12", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,16 @@ extern crate alloc;
 use core::{ops::{Deref, DerefMut}, mem::MaybeUninit, marker::PhantomData};
 
 use alloc::{vec::Vec, string::String, borrow::ToOwned};
+#[cfg(not(feature = "macros"))]
+use binmarshal_macros::Proxy;
 use rw::{BitView, BitWriter};
 
 pub use binmarshal_macros::{BinMarshal, Context, Proxy};
 
 pub mod rw;
+
+#[cfg(feature = "macros")]
+pub use binmarshal_macros::*;
 
 // See: https://github.com/rust-lang/rust/issues/86935
 pub type SelfType<T> = T;


### PR DESCRIPTION
Also uses cargo workspaces for building